### PR TITLE
Remove pip from dashboard setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,13 @@ A comprehensive dashboard for managing and monitoring VPN scanning operations.
 npm install
 ```
 
-3. Install Python dependencies:
-```bash
-pip install -r requirements.txt
-```
 
-4. Set up the environment:
+3. Set up the environment:
 
 ```bash
 npm run setup
 ```
-The command accepts an optional `--runtime` flag (`node` or `python`) to install
-dependencies for the desired environment. The default is `node`.
+The command installs all required Node and Go tooling.
 
 ### Running the Dashboard
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -22,7 +22,6 @@ func runSetup(cfgPath string) error {
 	}{
 		{"go", []string{"mod", "download"}},
 		{"npm", []string{"install"}},
-		{"python3", []string{"-m", "pip", "install", "-r", "requirements.txt"}},
 	}
 	for _, c := range cmds {
 		cmd := exec.Command(c.name, c.args...)


### PR DESCRIPTION
## Summary
- remove Python dependency installation from `runSetup`
- update dashboard setup instructions in README

## Testing
- `npm install`
- `go mod download`
- `go test ./...` *(fails: package not found)*
- `npx vitest run` *(fails: Can not find dependency 'jsdom')*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686641556fb0832da4416601a7e4af22