### PR TITLE
Update docs for Go workflow

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -6,7 +6,7 @@
 - **Frontend**: React + TypeScript + Tailwind CSS
 - **Backend**: Go API сервер с WebSocket поддержкой  
 - **Database**: PostgreSQL (встроенная + Supabase)
-- **Workers**: Python/Go скрипты на удаленных серверах
+- **Workers**: Go binaries на удаленных серверах
 
 ---
 
@@ -158,12 +158,10 @@ func rateLimitMiddleware(next http.Handler) http.Handler {
 
 ---
 
-## 🐍 Python Workers анализ
+## 🦫 Go Workers анализ
 
-### Основные скрипты
-- `sers1.py` (Fortinet) - ✅ Хорошо реализован
+### Основные утилиты
 - `sers2.go` (GlobalProtect) - ⚠️ Требует обновления
-- `aggregator.py` - ✅ Отличная реализация
 
 **Общие проблемы**:
 - Отсутствие единого стандарта логирования
@@ -176,7 +174,7 @@ func rateLimitMiddleware(next http.Handler) http.Handler {
 
 ### Критические проблемы
 1. **Хранение credentials в plaintext**
-   ```python
+   ```text
    # В credentials.txt
    192.168.1.1;admin;password123  # Небезопасно!
    ```
@@ -244,8 +242,6 @@ npm run test
 # Backend  
 go test ./...
 
-# Python workers
-python -m pytest tests/
 ```
 
 ### Integration Tests

--- a/README.md
+++ b/README.md
@@ -29,18 +29,11 @@ A comprehensive dashboard for managing and monitoring VPN scanning operations.
 npm install
 ```
 
-3. Install Python dependencies:
-```bash
-pip install -r requirements.txt
-```
-
-4. Set up the environment:
+3. Set up the environment:
 
 ```bash
 npm run setup
 ```
-The command accepts an optional `--runtime` flag (`node` or `python`) to install
-dependencies for the desired environment. The default is `node`.
 
 ### Running the Dashboard
 
@@ -66,13 +59,22 @@ You can specify a VPN type:
 npm run test-vpn -- --vpn-type fortinet
 ```
 
-You can also run the Python scanner directly:
-
-```bash
-python3 vpn_scanner.py --vpn-type fortinet --creds-file creds/fortinet.txt
-```
 
 Add `--insecure` if the target uses self-signed certificates.
+### Running Go Binaries
+
+Build the dashboard and scanner binaries:
+```bash
+go build -o bin/dashboard ./cmd/dashboard
+go build -o bin/scanner sers2.go
+```
+
+Run the dashboard and scanner:
+```bash
+./bin/dashboard -port 8080
+./bin/scanner --config config.txt
+```
+
 
 ### Working with Remote Servers
 
@@ -96,10 +98,10 @@ npm run collect-results
 
 ## Testing
 
-Run Python unit tests:
+Run Go unit tests:
 
 ```bash
-pytest
+go test ./...
 ```
 
 > **Note**: Some Go tests use an embedded Postgres instance that cannot run as


### PR DESCRIPTION
## Summary
- drop Python instructions from README and the audit report
- explain how to build and run Go binaries
- note Go tests rather than pytest in docs

## Testing
- `go test ./...` *(fails: package vpn-bruteforce-client/internal/websocket not found)*

------
https://chatgpt.com/codex/tasks/task_e_686641579e48832d91a632f92fa0f15d