### PR TITLE
Switch to Go binaries for scanner scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "test:db": "vitest run tests/database_test.js",
     "test:api": "vitest run tests/api_test.js",
     "test:migration": "vitest run tests/migration_test.js",
-    "test:all": "vitest run"
+    "test:all": "vitest run",
+    "test-vpn": "node scripts/test-vpn.js",
+    "deploy-scripts": "node scripts/deploy-scripts.js",
+    "start-scanners": "node scripts/start-scanners.js",
+    "collect-results": "node scripts/collect-results.js"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.7",

--- a/scripts/start-scanners.js
+++ b/scripts/start-scanners.js
@@ -44,15 +44,15 @@ async function parseCredentialsFile(filePath) {
 // Get script name for VPN type
 function getScriptForVpnType(vpnType) {
   const scripts = {
-    'fortinet': 'sers1.py',
-    'paloalto': 'sers2.go',
-    'sonicwall': 'sers3.py',
-    'sophos': 'test_scanner.py --vpn-type sophos',
-    'watchguard': 'test_scanner.py --vpn-type watchguard',
-    'cisco': 'sers4.go'
+    'fortinet': 'sers1',
+    'paloalto': 'sers2',
+    'sonicwall': 'sers3',
+    'sophos': 'test_scanner --vpn-type sophos',
+    'watchguard': 'test_scanner --vpn-type watchguard',
+    'cisco': 'sers4'
   };
   
-  return scripts[vpnType.toLowerCase()] || `test_scanner.py --vpn-type ${vpnType}`;
+  return scripts[vpnType.toLowerCase()] || `test_scanner --vpn-type ${vpnType}`;
 }
 
 // Start scanner on a server
@@ -68,14 +68,7 @@ async function startScannerOnServer(server, vpnType) {
     const remoteDir = '/root/NAM/Servis';
     
     // Construct command
-    let cmd;
-    if (script.endsWith('.py')) {
-      cmd = `cd ${remoteDir} && python3 ${script}`;
-    } else if (script.endsWith('.go')) {
-      cmd = `cd ${remoteDir} && go run ${script}`;
-    } else {
-      cmd = `cd ${remoteDir} && ./${script}`;
-    }
+    const cmd = `cd ${remoteDir} && ./${script}`;
     
     console.log(`📋 Command: ${cmd}`);
     


### PR DESCRIPTION
## Summary
- build `test_scanner` Go binary in setup script
- run Go binaries instead of interpreted scripts in start-scanners
- expose helper scripts via npm

## Testing
- `npm test` *(fails: vitest not found)*
- `go test ./...` *(fails: package not in std)*

------
https://chatgpt.com/codex/tasks/task_e_686649c8b05c832dbde0ecf49ff9c4ce