### PR TITLE
Use Node built-in fetch

### DIFF
--- a/scripts/test-vpn.js
+++ b/scripts/test-vpn.js
@@ -10,7 +10,10 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import https from 'https';
 import { HttpsProxyAgent } from 'https-proxy-agent';
-import fetch from 'node-fetch';
+
+// Node.js 20 includes a global fetch implementation, so no external
+// dependency is required.
+const fetch = globalThis.fetch;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');


### PR DESCRIPTION
## Summary
- remove `node-fetch` dependency usage in `scripts/test-vpn.js`
- rely on built-in fetch in Node.js 20

## Testing
- `npm run test-vpn -- --vpn-type all --verbose`

------
https://chatgpt.com/codex/tasks/task_e_686652b90648832dba0ccdd0e4ea3993